### PR TITLE
Change import style on css module imports

### DIFF
--- a/src/lib/desktop-menu/desktop-menu.js
+++ b/src/lib/desktop-menu/desktop-menu.js
@@ -1,5 +1,5 @@
-import React, { Suspense } from 'react';
-import styles from './desktop-menu.module.css';
+import React from 'react';
+import {menuDrop, hiddenSm, hiddenXs, ignore, Menu} from './desktop-menu.module.css';
 import cs from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
@@ -18,7 +18,7 @@ class DesktopMenu extends React.Component {
 
   render() {
     return (
-      <div className={cs(styles.menuDrop, styles.hiddenXs, styles.hiddenSm)}>
+      <div className={cs(menuDrop, hiddenXs, hiddenSm)}>
         <ul>
           {this.props.menuModel && this.props.menuModel.menuItems.map((item, index) => {
             return (
@@ -26,16 +26,16 @@ class DesktopMenu extends React.Component {
                 {!item.children && (
                   <a
                     href={item.navigateUrl ? item.navigateUrl : null}
-                    className={cs(styles.ignore, 'unstyled')}>
+                    className={cs(ignore, 'unstyled')}>
                     {item.text}
                   </a>
                 )}{' '}
                 {item.children && (
                   <>
-                    <a className={cs(styles.ignore, 'unstyled')}>
+                    <a className={cs(ignore, 'unstyled')}>
                       {item.text} <FontAwesomeIcon icon={faAngleDown} />
                     </a>
-                    <div className={styles.Menu}>
+                    <div className={Menu}>
                         <MenuPanel item={item} prefix={this.props.prefix}/> 
                     </div>                            
                   </>

--- a/src/lib/dropdown-item/dropdown-item.js
+++ b/src/lib/dropdown-item/dropdown-item.js
@@ -1,40 +1,63 @@
-import React from 'react';
-import styles from './dropdown-item.module.css';
-import cs from 'classnames';
-
+import React from "react";
+import {
+  NonClickableMenuItem,
+  level1,
+  level2,
+  ignore,
+  ClickableMenuItem,
+} from "./dropdown-item.module.css";
+import cs from "classnames";
 
 const DropdownItem = ({ item, index }) => {
+  const styles = [
+    NonClickableMenuItem,
+    level1,
+    level2,
+    ignore,
+    ClickableMenuItem,
+  ];
+  const l1Class = item.data.navigateUrlOnMobileOnly
+    ? cs(NonClickableMenuItem, level1)
+    : item.data.cssClass
+    ? cs(styles[item.data.cssClass], level1)
+    : level1;
 
-    const l1Class =  item.data.navigateUrlOnMobileOnly ? 
-    cs(styles.NonClickableMenuItem, styles.level1)
-    : (item.data.cssClass ? cs(styles[item.data.cssClass], styles.level1) : styles.level1);
-
-
-    return (
-        <>
-            {item.level === 1 &&
-                <li key={index} className={l1Class} >
-                    {(!item.data.navigateUrl || item.data.navigateUrlOnMobileOnly) &&
-                        <span className={cs(styles.ignore, 'unstyled')}>
-                            {item.data.text}
-                        </span>
-                    }
-                    {item.data.navigateUrl && !item.data.navigateUrlOnMobileOnly &&
-                        <a href={item.navigateUrl ? item.navigateUrl : null} className={cs(styles.ignore, 'unstyled')}>
-                            {item.data.text}
-                        </a>
-                    }
-                </li>
-            }
-            {item.level === 2 &&
-                <li key={index} className={(item.data.cssClass ? cs(styles[item.data.cssClass], styles.ClickableMenuItem, styles.level2) : cs(styles.ClickableMenuItem, styles.level2))}>
-                    <a href={item.navigateUrl ? item.navigateUrl : null} className={cs(styles.ignore, 'unstyled')}>
-                        {item.data.text}
-                    </a>
-                </li>
-            }
-        </>
-    )
-}
+  return (
+    <>
+      {item.level === 1 && (
+        <li key={index} className={l1Class}>
+          {(!item.data.navigateUrl || item.data.navigateUrlOnMobileOnly) && (
+            <span className={cs(ignore, "unstyled")}>{item.data.text}</span>
+          )}
+          {item.data.navigateUrl && !item.data.navigateUrlOnMobileOnly && (
+            <a
+              href={item.navigateUrl ? item.navigateUrl : null}
+              className={cs(ignore, "unstyled")}
+            >
+              {item.data.text}
+            </a>
+          )}
+        </li>
+      )}
+      {item.level === 2 && (
+        <li
+          key={index}
+          className={
+            item.data.cssClass
+              ? cs(styles[item.data.cssClass], ClickableMenuItem, level2)
+              : cs(ClickableMenuItem, level2)
+          }
+        >
+          <a
+            href={item.navigateUrl ? item.navigateUrl : null}
+            className={cs(ignore, "unstyled")}
+          >
+            {item.data.text}
+          </a>
+        </li>
+      )}
+    </>
+  );
+};
 
 export default DropdownItem;

--- a/src/lib/dropdown/dropdown.js
+++ b/src/lib/dropdown/dropdown.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import DropdownItem from '../dropdown-item/dropdown-item'
-import styles from './dropdown.module.css';
+import {colMd3, MenuWrapper} from './dropdown.module.css';
 
 const Dropdown = ({ items }) => {
     const CountChildren = (items) => {
@@ -45,7 +45,7 @@ const Dropdown = ({ items }) => {
 
         return (
             blocks.map((column, index) => {
-                return (<ul key={index} className={styles.colMd3}>
+                return (<ul key={index} className={colMd3}>
                     {
                         column.map((item, index) => {
                             return <DropdownItem key={index} item={item}></DropdownItem>;
@@ -57,7 +57,7 @@ const Dropdown = ({ items }) => {
     }
 
     return (
-        <div className={styles.MenuWrapper}>{createDropDown(items)}</div>
+        <div className={MenuWrapper}>{createDropDown(items)}</div>
     );
 }
 

--- a/src/lib/menu-panel/menu-panel.js
+++ b/src/lib/menu-panel/menu-panel.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styles from './menu-panel.module.css';
+import { MenuImg } from './menu-panel.module.css';
 import Dropdown from '../dropdown/dropdown';
 
 
@@ -15,7 +15,7 @@ const MenuPanel = ({ item, prefix }) => {
     }
     return (
         <>
-            <div className={styles.MenuImg}>
+            <div className={MenuImg}>
                 <img src={getRootUrl() + require("../images/" + item.groupImageUrl).default} alt={item.text} loading="eager" />
             </div>
             <Dropdown items={item.children}></Dropdown>

--- a/src/lib/menu/menu.js
+++ b/src/lib/menu/menu.js
@@ -1,79 +1,92 @@
-import React from 'react';
-import styles from './menu.module.css'
-import DesktopMenu from '../desktop-menu/desktop-menu'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBars } from '@fortawesome/free-solid-svg-icons';
-import cs from 'classnames';
-import axios from 'axios';
+import React from "react";
+import {
+  MegaMenu,
+  menuContent,
+  menuMobile,
+  visibleXs,
+  visibleSm,
+  sbToggleLeft,
+  menuSearch,
+  searchBox,
+} from "./menu.module.css";
+import DesktopMenu from "../desktop-menu/desktop-menu";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBars } from "@fortawesome/free-solid-svg-icons";
+import cs from "classnames";
+import axios from "axios";
 
 const searchUrl = `https://www.google.com.au/search?q=site:ssw.com.au%20`;
 class Menu extends React.Component {
-    menu_Search(search) {
-        if (window) {
-            window.open(searchUrl + search);
-        }
+  menu_Search(search) {
+    if (window) {
+      window.open(searchUrl + search);
     }
+  }
 
-    handleKeyDownOnMenuSearchInput(event) {
-        if (event.key === 'Enter') {
-            this.menu_Search(event.target.value);
-        }
+  handleKeyDownOnMenuSearchInput(event) {
+    if (event.key === "Enter") {
+      this.menu_Search(event.target.value);
     }
+  }
 
-
-
-    render() {
-        const { menuModel } = this.props;
-        return (
-            // this.state.menuModel &&
-            <div className={styles.MegaMenu}>
-                <div className={styles.menuContent}>
-                    <div className={cs(styles.menuMobile, styles.visibleXs, styles.visibleSm)}>
-                        <div className={styles.sbToggleLeft} onClick={() => this.props.onClickToggle()} >
-                            <FontAwesomeIcon icon={faBars} />
-                        </div>
-                    </div>
-                    <DesktopMenu prefix={this.props.prefix} menuModel={menuModel}></DesktopMenu>
-                    <div className={styles.menuSearch}>
-                        <input type="text" className={styles.searchBox} onKeyDown={(event) => this.handleKeyDownOnMenuSearchInput(event)} />
-                    </div>
-                </div>
+  render() {
+    const { menuModel } = this.props;
+    return (
+      // this.state.menuModel &&
+      <div className={MegaMenu}>
+        <div className={menuContent}>
+          <div className={cs(menuMobile, visibleXs, visibleSm)}>
+            <div
+              className={sbToggleLeft}
+              onClick={() => this.props.onClickToggle()}
+            >
+              <FontAwesomeIcon icon={faBars} />
             </div>
-        )
-
-    }
+          </div>
+          <DesktopMenu
+            prefix={this.props.prefix}
+            menuModel={menuModel}
+          ></DesktopMenu>
+          <div className={menuSearch}>
+            <input
+              type="text"
+              className={searchBox}
+              onKeyDown={(event) => this.handleKeyDownOnMenuSearchInput(event)}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 class Wrapper extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            menuModel: require('../data/menu.json'),
-            menuLoaded: false
-        };
-    }
+  constructor(props) {
+    super(props);
+    this.state = {
+      menuModel: require("../data/menu.json"),
+      menuLoaded: false,
+    };
+  }
 
-    componentDidMount() {
-        let currentComponent = this;
-        axios.get('https://SSWConsulting.github.io/SSW.Website.Menu.json/menu.json')
-            .then(function (response) {
-                currentComponent.setState({ menuModel: response.data });
-            })
-            .catch(function (error) {
-                console.log(error);
-            });
-    }
+  componentDidMount() {
+    let currentComponent = this;
+    axios
+      .get("https://SSWConsulting.github.io/SSW.Website.Menu.json/menu.json")
+      .then(function (response) {
+        currentComponent.setState({ menuModel: response.data });
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
 
-    render() {
-        const { menuModel, menuLoaded } = this.state;
+  render() {
+    const { menuModel, menuLoaded } = this.state;
 
-        return (
-            <Menu
-                menuModel={menuModel}
-                menuLoaded={menuLoaded}
-                {...this.props}
-            />
-        );
-    }
+    return (
+      <Menu menuModel={menuModel} menuLoaded={menuLoaded} {...this.props} />
+    );
+  }
 }
 
 export default Wrapper;

--- a/src/lib/mobile-dropdown-item/mobile-dropdown-item.js
+++ b/src/lib/mobile-dropdown-item/mobile-dropdown-item.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import styles from './mobile-dropdown-item.module.css';
+import {level1, ignore} from './mobile-dropdown-item.module.css';
 
 const MobileDropdownItem = ({ item, index }) => {
     return (
         <>
-            <li key={index} className={styles.level1} >
-                <a href={item.navigateUrl ?  item.navigateUrl : null} className={styles.ignore}>
+            <li key={index} className={level1} >
+                <a href={item.navigateUrl ?  item.navigateUrl : null} className={ignore}>
                     {item.text}
                 </a>
             </li>

--- a/src/lib/mobile-menu/mobile-menu.js
+++ b/src/lib/mobile-menu/mobile-menu.js
@@ -1,10 +1,21 @@
-import React, { useState, componentDidMount } from 'react';
-import styles from './mobile-menu.module.css';
-import cs from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
-import MobileDropdownItem from '../mobile-dropdown-item/mobile-dropdown-item';
-import axios from 'axios';
+import React from "react";
+import {
+  dropdown,
+  open,
+  sbSlidebar,
+  sbLeft,
+  menuDrop,
+  navbarCollapse,
+  ignore,
+  dropdownToggle,
+  dropdownMenu,
+  navbarNav,
+} from "./mobile-menu.module.css";
+import cs from "classnames";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAngleDown } from "@fortawesome/free-solid-svg-icons";
+import MobileDropdownItem from "../mobile-dropdown-item/mobile-dropdown-item";
+import axios from "axios";
 
 class MobileMenu extends React.Component {
   //const DesktopMenu = ({prefix}) => {
@@ -16,7 +27,8 @@ class MobileMenu extends React.Component {
   loadMenuModel() {
     if (!this.state.menuModel) {
       let currentComponent = this;
-      axios.get('https://SSWConsulting.github.io/SSW.Website.Menu.json/menu.json')
+      axios
+        .get("https://SSWConsulting.github.io/SSW.Website.Menu.json/menu.json")
         .then(function (response) {
           currentComponent.setState({ menuModel: response.data });
         })
@@ -31,30 +43,32 @@ class MobileMenu extends React.Component {
   }
 
   closeOpenedElements() {
-    var openedItems = document.getElementsByClassName(cs(styles.dropdown, styles.open));
+    var openedItems = document.getElementsByClassName(cs(dropdown, open));
     for (let item of openedItems) {
-      item.className = styles.dropdown;
+      item.className = dropdown;
     }
   }
 
   openElement(element) {
-    element.className = cs(styles.dropdown, styles.open);
+    element.className = cs(dropdown, open);
   }
 
   closeElement(element) {
-    element.className = styles.dropdown;
+    element.className = dropdown;
   }
 
   openItem(event) {
-    if (event.target.parentNode.className === styles.dropdown) {
+    if (event.target.parentNode.className === dropdown) {
       this.closeOpenedElements();
       this.openElement(event.target.parentNode);
-    } else if (event.target.parentNode.parentNode.className === styles.dropdown) {
+    } else if (event.target.parentNode.parentNode.className === dropdown) {
       this.closeOpenedElements();
       this.openElement(event.target.parentNode.parentNode);
-    } else if (event.target.parentNode.className === cs(styles.dropdown, styles.open)) {
+    } else if (event.target.parentNode.className === cs(dropdown, open)) {
       this.closeElement(event.target.parentNode);
-    } else if (event.target.parentNode.parentNode.className === cs(styles.dropdown, styles.open)) {
+    } else if (
+      event.target.parentNode.parentNode.className === cs(dropdown, open)
+    ) {
       this.closeElement(event.target.parentNode.parentNode);
     }
   }
@@ -62,42 +76,49 @@ class MobileMenu extends React.Component {
   render() {
     return (
       <div
-        className={cs(styles.sbSlidebar, styles.sbLeft)}
-        style={{ width: this.props.isMenuOpened ? '84vw' : '0px' }}
+        className={cs(sbSlidebar, sbLeft)}
+        style={{ width: this.props.isMenuOpened ? "84vw" : "0px" }}
         onClick={(event) => this.openItem(event)}
       >
-        <div className={cs(styles.menuDrop, styles.navbarCollapse)}>
-          <ul className={styles.navbarNav}>
-            {this.state.menuModel && this.state.menuModel.menuItems.map((item, index) => {
-              if (!item.children) {
-                return (
-                  <li key={index} className={styles.dropdown}>
-                    <a href={item.navigateUrl ? item.navigateUrl : null} className={cs(styles.ignore, 'unstyled')}>
-                      {item.text}
-                    </a>
-                  </li>
-                );
-              } else if (item.children) {
-                return (
-                  <li key={index} className={styles.dropdown}>
-                    <a className={cs(styles.dropdownToggle, 'unstyled')}>
-                      {item.text} <FontAwesomeIcon icon={faAngleDown} />
-                    </a>
-                    <ul className={styles.dropdownMenu}>
-                      {item.children.map((level1Item, indexLevel1) => {
-                        return (
-                          <MobileDropdownItem key={indexLevel1} item={level1Item} ></MobileDropdownItem>
-                        )
-                      })}
-                    </ul>
-                  </li>
-                );
-              }
-            })}
+        <div className={cs(menuDrop, navbarCollapse)}>
+          <ul className={navbarNav}>
+            {this.state.menuModel &&
+              this.state.menuModel.menuItems.map((item, index) => {
+                if (!item.children) {
+                  return (
+                    <li key={index} className={dropdown}>
+                      <a
+                        href={item.navigateUrl ? item.navigateUrl : null}
+                        className={cs(ignore, "unstyled")}
+                      >
+                        {item.text}
+                      </a>
+                    </li>
+                  );
+                } else if (item.children) {
+                  return (
+                    <li key={index} className={dropdown}>
+                      <a className={cs(dropdownToggle, "unstyled")}>
+                        {item.text} <FontAwesomeIcon icon={faAngleDown} />
+                      </a>
+                      <ul className={dropdownMenu}>
+                        {item.children.map((level1Item, indexLevel1) => {
+                          return (
+                            <MobileDropdownItem
+                              key={indexLevel1}
+                              item={level1Item}
+                            ></MobileDropdownItem>
+                          );
+                        })}
+                      </ul>
+                    </li>
+                  );
+                }
+              })}
           </ul>
         </div>
       </div>
     );
   }
-};
+}
 export default MobileMenu;


### PR DESCRIPTION
To make it compatible with Gatsby v3
For more information, see
https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#css-modules-are-imported-as-es-modules