### PR TITLE
fix mouse cursor when hovering over top level elements

### DIFF
--- a/lib/components/menu/desktop-menu/index.jsx
+++ b/lib/components/menu/desktop-menu/index.jsx
@@ -38,6 +38,7 @@ class DesktopMenu extends React.Component {
                         role="presentation"
                         className={cs(
                           styles.ignore,
+                          styles['cursor-pointer'],
                           styles['inline-block'],
                           'unstyled',
                         )}

--- a/lib/components/menu/desktop-menu/index.module.css
+++ b/lib/components/menu/desktop-menu/index.module.css
@@ -70,3 +70,6 @@
   content: none !important;
   padding-left: 0;
 }
+.cursor-pointer {
+  cursor: pointer;
+}


### PR DESCRIPTION
Bug - Mouse cursor was an I bar when hovering over top level menu elements

![CleanShot 2023-07-19 at 14 40 23](https://github.com/SSWConsulting/SSW.MegaMenu/assets/600044/9cf26c19-4410-42af-9ee3-86bf8d701901)


Fixed:

![CleanShot 2023-07-19 at 14 37 20](https://github.com/SSWConsulting/SSW.MegaMenu/assets/600044/14be6c5a-1bbb-472f-babb-466baa71ffcc)
