### PR TITLE
Changed react-useportal From External Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
-    "classnames": "^2.3.2",
-    "react-useportal": "^1.0.17"
+    "classnames": "^2.3.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.0.0",
@@ -36,6 +35,7 @@
     "prettier": "2.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-useportal": "^1.0.17",
     "stylelint": "^14.16.1",
     "stylelint-config-recommended": "^9.0.0",
     "typescript": "^4.9.5",

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
   ],
   build: {
     target: 'es6',
-    minify: false,
+    minify: "esbuild",
     copyPublicDir: false,
     lib: {
       entry: path.resolve(__dirname, 'lib/index.js'),
@@ -32,15 +32,13 @@ export default defineConfig({
         "classnames", 
         "@fortawesome/fontawesome-svg-core", 
         "@fortawesome/free-solid-svg-icons", 
-        "@fortawesome/react-fontawesome", 
-        "react-useportal"
+        "@fortawesome/react-fontawesome",
       ],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
           "classnames": "cs",
-          "react-useportal": "usePortal"
         },
       },
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
   ],
   build: {
     target: 'es6',
-    minify: "esbuild",
+    minify: false,
     copyPublicDir: false,
     lib: {
       entry: path.resolve(__dirname, 'lib/index.js'),
@@ -39,6 +39,8 @@ export default defineConfig({
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          "classnames": "cs",
+          "react-useportal": "usePortal"
         },
       },
     },


### PR DESCRIPTION
Fixes #40

Was experiencing some bugs with both Next.js and Vite deployments relating to importing `react-useportal`, so this was changed to have react-useportal bundled into the app. 
