### PR TITLE
🏗️ Types - Correct Exports

### DIFF
--- a/lib/components/MegaIcon/MegaIcon.tsx
+++ b/lib/components/MegaIcon/MegaIcon.tsx
@@ -1,58 +1,6 @@
-import {
-  ChevronDownIcon,
-  ChevronLeftIcon,
-  MagnifyingGlassIcon,
-  PhoneIcon,
-  PlayCircleIcon,
-  RectangleGroupIcon,
-} from "@heroicons/react/20/solid";
-import {
-  ChartPieIcon,
-  CursorArrowRaysIcon,
-  FingerPrintIcon,
-  SquaresPlusIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
 import React from "react";
+import { AvailableIcons, iconMap } from "../../types/icon";
 import { CustomImage } from "../CustomImage";
-import { Flag } from "../Flag";
-
-type IconProps = {
-  className?: string;
-};
-
-export type AvailableIcons = keyof typeof iconMap;
-
-const iconMap = {
-  chevronDown: (props: IconProps) => (
-    <ChevronDownIcon className={props.className} />
-  ),
-  chevronLeft: (props: IconProps) => (
-    <ChevronLeftIcon className={props.className} />
-  ),
-  magnifyingGlass: (props: IconProps) => (
-    <MagnifyingGlassIcon className={props.className} />
-  ),
-  phone: (props: IconProps) => <PhoneIcon className={props.className} />,
-  xMark: (props: IconProps) => <XMarkIcon className={props.className} />,
-  chartPie: (props: IconProps) => <ChartPieIcon className={props.className} />,
-  cursorArrowRays: (props: IconProps) => (
-    <CursorArrowRaysIcon className={props.className} />
-  ),
-  fingerPrint: (props: IconProps) => (
-    <FingerPrintIcon className={props.className} />
-  ),
-  squaresPlus: (props: IconProps) => (
-    <SquaresPlusIcon className={props.className} />
-  ),
-  playCircle: (props: IconProps) => (
-    <PlayCircleIcon className={props.className} />
-  ),
-  rectangleGroup: (props: IconProps) => (
-    <RectangleGroupIcon className={props.className} />
-  ),
-  chinaFlag: () => <Flag country="China" className="mr-2" />,
-};
 
 const MegaIconMapper = ({
   icon,

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -27,12 +27,12 @@ export type MegaMenuWrapperProps = {
 } & React.PropsWithChildren &
   (Tagline | Title);
 
-type Tagline = {
+export type Tagline = {
   title?: never;
   tagline?: string;
 };
 
-type Title = {
+export type Title = {
   title: string;
   tagline?: never;
 };

--- a/lib/components/SubMenuGroup/FeaturedCard.tsx
+++ b/lib/components/SubMenuGroup/FeaturedCard.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from "react";
-import { AvailableIcons, MegaIcon } from "../MegaIcon";
+import { AvailableIcons } from "../../types/icon";
+import { MegaIcon } from "../MegaIcon";
 
 interface FeaturedCardProps extends PropsWithChildren {
   title: React.ReactNode;

--- a/lib/components/SubMenuGroup/SubMenuGroup.tsx
+++ b/lib/components/SubMenuGroup/SubMenuGroup.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useContext } from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
+import { AvailableIcons } from "../../types/icon";
 import {
   NavMenuColumn,
   NavMenuColumnGroup,
@@ -10,7 +11,7 @@ import {
 } from "../../types/megamenu";
 import { cx } from "../../util/cx";
 import { ClosePopoverContext } from "../DesktopMenu/DesktopMenu";
-import { MegaIcon, type AvailableIcons } from "../MegaIcon";
+import { MegaIcon } from "../MegaIcon";
 import SubMenuWidget from "./SubMenuWidget";
 
 export interface SubMenuGroupProps {

--- a/lib/components/SubMenuGroup/SubMenuWidget.tsx
+++ b/lib/components/SubMenuGroup/SubMenuWidget.tsx
@@ -1,8 +1,9 @@
 "use client";
 import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
+import { AvailableIcons } from "../../types/icon";
 import { SidebarItem } from "../../types/megamenu";
-import { AvailableIcons, MegaIcon } from "../MegaIcon";
+import { MegaIcon } from "../MegaIcon";
 import FeaturedCard from "./FeaturedCard";
 
 interface SubMenuWidgetProps {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,8 @@
-import { MegaMenuLayout } from "./components";
 import "./index.css";
 
-export { MegaMenuLayout };
+export * from "./components/MegaMenuLayout";
+export type { LinkComponentType } from "./hooks/useLinkComponent";
+
+export * from "./types/country";
+export * from "./types/icon";
+export * from "./types/megamenu";

--- a/lib/types/icon.tsx
+++ b/lib/types/icon.tsx
@@ -1,0 +1,54 @@
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  MagnifyingGlassIcon,
+  PhoneIcon,
+  PlayCircleIcon,
+  RectangleGroupIcon,
+} from "@heroicons/react/20/solid";
+import {
+  ChartPieIcon,
+  CursorArrowRaysIcon,
+  FingerPrintIcon,
+  SquaresPlusIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+
+import { Flag } from "../components/Flag";
+
+export type IconProps = {
+  className?: string;
+};
+
+export type AvailableIcons = keyof typeof iconMap;
+
+export const iconMap = {
+  chevronDown: (props: IconProps) => (
+    <ChevronDownIcon className={props.className} />
+  ),
+  chevronLeft: (props: IconProps) => (
+    <ChevronLeftIcon className={props.className} />
+  ),
+  magnifyingGlass: (props: IconProps) => (
+    <MagnifyingGlassIcon className={props.className} />
+  ),
+  phone: (props: IconProps) => <PhoneIcon className={props.className} />,
+  xMark: (props: IconProps) => <XMarkIcon className={props.className} />,
+  chartPie: (props: IconProps) => <ChartPieIcon className={props.className} />,
+  cursorArrowRays: (props: IconProps) => (
+    <CursorArrowRaysIcon className={props.className} />
+  ),
+  fingerPrint: (props: IconProps) => (
+    <FingerPrintIcon className={props.className} />
+  ),
+  squaresPlus: (props: IconProps) => (
+    <SquaresPlusIcon className={props.className} />
+  ),
+  playCircle: (props: IconProps) => (
+    <PlayCircleIcon className={props.className} />
+  ),
+  rectangleGroup: (props: IconProps) => (
+    <RectangleGroupIcon className={props.className} />
+  ),
+  chinaFlag: () => <Flag country="China" className="mr-2" />,
+};

--- a/lib/types/megamenu.ts
+++ b/lib/types/megamenu.ts
@@ -1,4 +1,4 @@
-import type { AvailableIcons } from "../components/MegaIcon";
+import { AvailableIcons } from "./icon";
 
 export const availableWidgets = [
   "standardLink",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssw.megamenu",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,21 @@ import dts from "vite-plugin-dts";
 export default defineConfig({
   plugins: [
     react(),
-    dts({ rollupTypes: true }),
+    dts({
+      rollupTypes: true,
+      // config relating to api-extractor, which rolls up the types
+      rollupConfig: {
+        messages: {
+          extractorMessageReporting: {
+            "ae-forgotten-export": {
+              // @ts-expect-error - this is a valid config
+              logLevel: "warning",
+              addToApiReportFile: true,
+            },
+          },
+        },
+      },
+    }),
     { ...nodeExternals(), enforce: "pre" },
   ],
   build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
             "ae-forgotten-export": {
               // @ts-expect-error - this is a valid config
               logLevel: "warning",
-              addToApiReportFile: true,
             },
           },
         },


### PR DESCRIPTION
<!-- Include the issue it closes -->
Fixes #73 

<!-- Summarize your changes -->

* Moved types of `MegaIcon` to `types/icon.tsx` 
* Made `index.ts` export all types from the `types` folder 
* Added warnings for types that haven't been exported during `api-extractor` rollup 

![image](https://github.com/SSWConsulting/SSW.MegaMenu/assets/20507092/526400b4-0320-4e27-b47e-d69429356ada)
**Figure: Before**

![image](https://github.com/SSWConsulting/SSW.MegaMenu/assets/20507092/f055f41c-02ba-4fda-ac51-dfdfc14a5643)
**Figure: After**

<!-- include screenshots if relevant -->
