### PR TITLE
Fixing button borders

### DIFF
--- a/lib/components/PhoneButton/PhoneButton.tsx
+++ b/lib/components/PhoneButton/PhoneButton.tsx
@@ -1,7 +1,7 @@
 import { isMobile } from "react-device-detect";
 // Fix for Next.js as per https://github.com/react-icons/react-icons/issues/821#issuecomment-1747679972
 import { useEffect, useState } from "react";
-import { FaPhoneAlt } from "react-icons/fa/index.js";
+import { MegaIcon } from "../MegaIcon";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { cx } from "../../util/cx";
 
@@ -33,7 +33,7 @@ export const PhoneButton = ({ className }: PhoneButtonProps) => {
           "flex h-12 w-full shrink-0 cursor-pointer items-center justify-center rounded bg-ssw-red px-5 text-xl hover:opacity-70 max-sm:my-5 sm:w-fit",
         )}
       >
-        <FaPhoneAlt color="white" className="text-2xl" />
+        <MegaIcon icon="phoneAlt" className="text-2xl text-white" />
         <span className="ml-2 inline text-sm font-bold text-white">{text}</span>
       </CustomLink>
     </div>

--- a/lib/components/PhoneButton/PhoneButton.tsx
+++ b/lib/components/PhoneButton/PhoneButton.tsx
@@ -30,7 +30,7 @@ export const PhoneButton = ({ className }: PhoneButtonProps) => {
       <CustomLink
         href={url}
         className={cx(
-          "flex h-12 w-full shrink-0 cursor-pointer items-center justify-center rounded-lg bg-ssw-red px-5 text-xl hover:opacity-70 max-sm:my-5 sm:w-fit",
+          "flex h-12 w-full shrink-0 cursor-pointer items-center justify-center rounded bg-ssw-red px-5 text-xl hover:opacity-70 max-sm:my-5 sm:w-fit",
         )}
       >
         <FaPhoneAlt color="white" className="text-2xl" />

--- a/lib/components/SubMenuGroup/FeaturedCard.tsx
+++ b/lib/components/SubMenuGroup/FeaturedCard.tsx
@@ -9,7 +9,7 @@ interface FeaturedCardProps extends PropsWithChildren {
 
 const FeaturedCard = (props: FeaturedCardProps) => {
   return (
-    <div className="rounded-md bg-ssw-black px-4 py-5 text-white hover:bg-ssw-gray">
+    <div className="rounded bg-ssw-black px-4 py-5 text-white hover:bg-ssw-gray">
       <div className="inline-flex items-center font-bold">
         {props.icon && <MegaIcon icon={props.icon} className="mr-2" />}
         {props.title}

--- a/lib/components/SubMenuGroup/SubMenuWidget.tsx
+++ b/lib/components/SubMenuGroup/SubMenuWidget.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { AvailableIcons } from "../../types/icon";
 import { SidebarItem } from "../../types/megamenu";
+import { MegaIcon } from "../MegaIcon";
 import FeaturedCard from "./FeaturedCard";
-import { FaPhoneAlt } from "react-icons/fa";
 
 interface SubMenuWidgetProps {
   item: SidebarItem;
@@ -32,7 +32,7 @@ const SubMenuWidget: React.FC<SubMenuWidgetProps> = ({ item }) => {
           className="relative flex w-full cursor-pointer items-center justify-center rounded bg-ssw-red font-semibold !text-white hover:bg-ssw-light-red"
           href={item.url}
         >
-          <FaPhoneAlt color="white" className="text-2xl" />
+          <MegaIcon icon="phoneAlt" className="text-2xl" />
           <span className="ml-2 py-4">{item.name.toUpperCase()}</span>
         </CustomLink>
       );

--- a/lib/components/SubMenuGroup/SubMenuWidget.tsx
+++ b/lib/components/SubMenuGroup/SubMenuWidget.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { AvailableIcons } from "../../types/icon";
 import { SidebarItem } from "../../types/megamenu";
-import { MegaIcon } from "../MegaIcon";
 import FeaturedCard from "./FeaturedCard";
+import { FaPhoneAlt } from "react-icons/fa";
 
 interface SubMenuWidgetProps {
   item: SidebarItem;
@@ -29,11 +29,11 @@ const SubMenuWidget: React.FC<SubMenuWidgetProps> = ({ item }) => {
     case "bookNow": {
       return (
         <CustomLink
-          className="relative flex w-full cursor-pointer items-center justify-center rounded-md bg-ssw-red font-semibold !text-white hover:bg-ssw-light-red"
+          className="relative flex w-full cursor-pointer items-center justify-center rounded bg-ssw-red font-semibold !text-white hover:bg-ssw-light-red"
           href={item.url}
         >
-          <MegaIcon icon="phone" className="h-6" />
-          <span className="ml-2 py-4">{item.name}</span>
+          <FaPhoneAlt color="white" className="text-2xl" />
+          <span className="ml-2 py-4">{item.name.toUpperCase()}</span>
         </CustomLink>
       );
     }

--- a/lib/components/SubMenuGroup/SubMenuWidget.tsx
+++ b/lib/components/SubMenuGroup/SubMenuWidget.tsx
@@ -33,7 +33,7 @@ const SubMenuWidget: React.FC<SubMenuWidgetProps> = ({ item }) => {
           href={item.url}
         >
           <MegaIcon icon="phoneAlt" className="text-2xl" />
-          <span className="ml-2 py-4">{item.name.toUpperCase()}</span>
+          <span className="ml-2 py-4">{item.name?.toUpperCase()}</span>
         </CustomLink>
       );
     }

--- a/lib/types/icon.tsx
+++ b/lib/types/icon.tsx
@@ -13,6 +13,7 @@ import {
   SquaresPlusIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import { FaPhoneAlt } from "react-icons/fa";
 
 import { Flag } from "../components/Flag";
 
@@ -33,6 +34,7 @@ export const iconMap = {
     <MagnifyingGlassIcon className={props.className} />
   ),
   phone: (props: IconProps) => <PhoneIcon className={props.className} />,
+  phoneAlt: (props: IconProps) => <FaPhoneAlt className={props.className} />,
   xMark: (props: IconProps) => <XMarkIcon className={props.className} />,
   chartPie: (props: IconProps) => <ChartPieIcon className={props.className} />,
   cursorArrowRays: (props: IconProps) => (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssw.megamenu",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
- Set border radius to 0.25rem for buttons
- Set border radius to 0.25rem for feature cards
- Change Book Now phone icon to match Contact Us button and uppercase the text

Fixes: https://github.com/SSWConsulting/SSW.Website/issues/2175

![image](https://github.com/SSWConsulting/SSW.MegaMenu/assets/87786621/05b1529f-e895-49a7-baf4-49d026b8e951)
**Figure: Changes made to buttons and cards**