### PR TITLE
Add language options on mobile

### DIFF
--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -6,7 +6,7 @@ import { Countries } from "../../types/country";
 import { cx } from "../../util/cx";
 import { Flag } from "../Flag";
 
-const websites: { country: Countries; url: string }[] = [
+export const websites: { country: Countries; url: string }[] = [
   {
     country: "Australia",
     url: "https://www.ssw.com.au",
@@ -49,7 +49,7 @@ const CountryDropdown = ({ url }: CountryDropdownProps) => {
     <Popover>
       <Popover.Button
         className={cx(
-          "flex items-center justify-center gap-x-1 rounded-md px-4 py-1 text-sm font-semibold text-ssw-black outline-none",
+          "flex items-center justify-center gap-x-1 rounded-md px-1 py-1 text-sm font-semibold text-ssw-black outline-none xl:px-4",
           "hover:bg-gray-100",
           isOpened && "bg-gray-100",
         )}
@@ -73,7 +73,7 @@ const CountryDropdown = ({ url }: CountryDropdownProps) => {
             .map((country) => (
               <CustomLink
                 key={country.country}
-                className="block py-2 hover:bg-gray-100 lg:min-w-[80px]"
+                className="block min-w-[80px] py-2 hover:bg-gray-100"
                 href={country.url}
                 title={country.country}
               >

--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -49,7 +49,7 @@ const CountryDropdown = ({ url }: CountryDropdownProps) => {
     <Popover>
       <Popover.Button
         className={cx(
-          "flex items-center justify-center gap-x-1 rounded-md px-1 py-1 text-sm font-semibold text-ssw-black outline-none xl:px-4",
+          "flex items-center justify-center gap-x-1 rounded-md px-4 py-1 text-sm font-semibold text-ssw-black outline-none",
           "hover:bg-gray-100",
           isOpened && "bg-gray-100",
         )}

--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -49,7 +49,7 @@ const CountryDropdown = ({ url }: CountryDropdownProps) => {
     <Popover>
       <Popover.Button
         className={cx(
-          "flex items-center justify-center gap-x-1 rounded-md px-4 py-1 text-sm font-semibold text-ssw-black outline-none",
+          "xs:px-4 flex items-center justify-center gap-x-1 rounded-md px-1 py-1 text-sm font-semibold text-ssw-black outline-none",
           "hover:bg-gray-100",
           isOpened && "bg-gray-100",
         )}

--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -6,7 +6,7 @@ import { Countries } from "../../types/country";
 import { cx } from "../../util/cx";
 import { Flag } from "../Flag";
 
-export const websites: { country: Countries; url: string }[] = [
+const websites: { country: Countries; url: string }[] = [
   {
     country: "Australia",
     url: "https://www.ssw.com.au",

--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -49,7 +49,7 @@ const CountryDropdown = ({ url }: CountryDropdownProps) => {
     <Popover>
       <Popover.Button
         className={cx(
-          "xs:px-4 flex items-center justify-center gap-x-1 rounded-md px-1 py-1 text-sm font-semibold text-ssw-black outline-none",
+          "flex items-center justify-center gap-x-1 rounded-md px-1 py-1 text-sm font-semibold text-ssw-black outline-none xs:px-4",
           "hover:bg-gray-100",
           isOpened && "bg-gray-100",
         )}

--- a/lib/components/DesktopMenu/DesktopMenu.tsx
+++ b/lib/components/DesktopMenu/DesktopMenu.tsx
@@ -3,11 +3,11 @@ import React, { createContext } from "react";
 import { NavMenuGroup } from "../../types/megamenu";
 import { CountryDropdown } from "../CountryDropdown";
 import { PhoneButton } from "../PhoneButton";
-import { Search } from "../Search";
+import { Search, SearchTermProps } from "../Search";
 import { MenuItemLink } from "./MenuItemLink";
 import { MenuItemWithSubmenu } from "./MenuItemWithSubmenu";
 
-export interface DesktopMenuProps {
+export interface DesktopMenuProps extends SearchTermProps {
   menuGroups: NavMenuGroup[];
   sideActionsOverride?: () => JSX.Element;
   hidePhone?: boolean;
@@ -23,6 +23,9 @@ const DesktopMenu: React.FC<DesktopMenuProps> = ({
   hidePhone,
   searchUrl,
   callback,
+  performSearch,
+  searchTerm,
+  setSearchTerm,
 }) => {
   const SideActions = sideActionsOverride;
 
@@ -78,6 +81,9 @@ const DesktopMenu: React.FC<DesktopMenuProps> = ({
           <SideActions />
         ) : (
           <DefaultSideActions
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+            performSearch={performSearch}
             hidePhone={hidePhone}
             searchUrl={searchUrl}
             callback={callback}
@@ -88,21 +94,27 @@ const DesktopMenu: React.FC<DesktopMenuProps> = ({
   );
 };
 
-type DefaultSideActionsProps = {
+interface DefaultSideActionsProps extends SearchTermProps {
   hidePhone?: boolean;
   searchUrl: string;
   callback?: (searchTerm: string) => void;
-};
+}
 
 const DefaultSideActions = ({
   hidePhone,
   searchUrl,
-  callback,
+  searchTerm,
+  setSearchTerm,
+  performSearch,
 }: DefaultSideActionsProps) => {
   return (
     <>
       {!hidePhone && <PhoneButton />}
-      <Search url={searchUrl} callback={callback} />
+      <Search
+        performSearch={performSearch}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+      />
       <Divider />
       <CountryDropdown url={searchUrl} />
     </>

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -139,7 +139,6 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
           searchTerm={searchTerm}
           setSearchTerm={setSearchTerm}
           performSearch={performSearch}
-          searchUrl={searchUrl}
           isMobileMenuOpen={isMobileMenuOpen}
           menuBarItems={menuItems}
           closeMobileMenu={() => setMobileMenuOpen(false)}

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -50,13 +50,27 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
   rightSideActionsOverride,
   callback,
 }) => {
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const performSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (searchTerm) {
+      if (callback) {
+        callback(searchTerm);
+      } else {
+        const searchUrl = `https://www.google.com.au/search?q=site:${url}%20${encodeURIComponent(
+          searchTerm,
+        )}`;
+        window.open(searchUrl, "_blank");
+      }
+    }
+  };
+
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const { menuItems } = useMenuItems(menuBarItems);
   const CustomLink = useLinkComponent();
 
   const RightSideActions = rightSideActionsOverride;
-
   return (
     <LinkProvider linkComponent={linkComponent}>
       <div
@@ -112,14 +126,19 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
             </button>
           </div>
           <DesktopMenu
+            setSearchTerm={setSearchTerm}
+            searchTerm={searchTerm}
+            performSearch={performSearch}
             searchUrl={searchUrl}
             menuGroups={menuItems}
             sideActionsOverride={rightSideActionsOverride}
             callback={callback}
           />
         </nav>
-
         <MobileMenu
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+          performSearch={performSearch}
           searchUrl={searchUrl}
           isMobileMenuOpen={isMobileMenuOpen}
           menuBarItems={menuItems}

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -10,11 +10,11 @@ import { useMenuItems } from "../../hooks/useMenuItems";
 import { NavMenuGroup } from "../../types/megamenu";
 import { DEFAULT_URL } from "../../util/constants";
 import { cx } from "../../util/cx";
+import { CountryDropdown } from "../CountryDropdown";
 import DesktopMenu from "../DesktopMenu/DesktopMenu";
 import { Logo } from "../Logo";
 import MobileMenu from "../MobileMenu/MobileMenu";
 import { PhoneButton } from "../PhoneButton";
-import { Search } from "../Search";
 
 export type MegaMenuWrapperProps = {
   className?: ClassValue;
@@ -100,7 +100,7 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
             ) : (
               <PhoneButton className="max-sm:hidden" />
             )}
-            <Search url={searchUrl} callback={callback} />
+            <CountryDropdown />
             <Divider />
             <button
               type="button"

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -80,7 +80,7 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
         )}
       >
         <nav
-          className="xs:gap-x-4 flex h-full w-full items-center justify-between gap-x-1 overflow-hidden px-0"
+          className="flex h-full w-full items-center justify-between gap-x-1 overflow-hidden px-0 xs:gap-x-4"
           aria-label="Global"
         >
           <div className="flex items-center">
@@ -118,7 +118,7 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
             <Divider />
             <button
               type="button"
-              className="xs:px-4 inline-flex items-center justify-center rounded-md px-1 text-gray-700"
+              className="inline-flex items-center justify-center rounded-md px-1 text-gray-700 xs:px-4"
               onClick={() => setMobileMenuOpen(true)}
             >
               <span className="sr-only">Open main menu</span>

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -120,6 +120,7 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
         </nav>
 
         <MobileMenu
+          searchUrl={searchUrl}
           isMobileMenuOpen={isMobileMenuOpen}
           menuBarItems={menuItems}
           closeMobileMenu={() => setMobileMenuOpen(false)}

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -57,10 +57,10 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
       if (callback) {
         callback(searchTerm);
       } else {
-        const searchUrl = `https://www.google.com.au/search?q=site:${url}%20${encodeURIComponent(
+        const queryUrl = `https://www.google.com.au/search?q=site:${searchUrl}%20${encodeURIComponent(
           searchTerm,
         )}`;
-        window.open(searchUrl, "_blank");
+        window.open(queryUrl, "_blank");
       }
     }
   };

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -118,7 +118,7 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
             <Divider />
             <button
               type="button"
-              className="-m-2.5 inline-flex items-center justify-center rounded-md pl-6 pr-2 text-gray-700"
+              className="xs:px-4 inline-flex items-center justify-center rounded-md px-1 text-gray-700"
               onClick={() => setMobileMenuOpen(true)}
             >
               <span className="sr-only">Open main menu</span>

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -80,7 +80,7 @@ const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({
         )}
       >
         <nav
-          className="flex h-full w-full items-center justify-between gap-x-4 overflow-hidden px-0"
+          className="xs:gap-x-4 flex h-full w-full items-center justify-between gap-x-1 overflow-hidden px-0"
           aria-label="Global"
         >
           <div className="flex items-center">

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -11,7 +11,6 @@ export interface MobileMenuProps extends SearchTermProps {
   isMobileMenuOpen: boolean;
   menuBarItems: NavMenuGroup[];
   closeMobileMenu: () => void;
-  searchUrl: string;
 }
 
 const MobileMenu: React.FC<MobileMenuProps> = ({
@@ -85,7 +84,6 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
 interface MenuBarItemProps extends SearchTermProps {
   menuBarItems: NavMenuGroup[];
   setSelectedMenuItem: (item: NavMenuGroup) => void;
-  searchUrl: string;
 }
 const MenuBarItems: React.FC<MenuBarItemProps> = ({
   menuBarItems,

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -123,20 +123,20 @@ const MenuBarItems: React.FC<MenuBarItemProps> = ({
           );
         })}
       </div>
-      <SearchButton
+      <SearchInput
         performSearch={performSearch}
         setSearchTerm={setSearchTerm}
         searchTerm={searchTerm}
         className="relative pr-6"
-      ></SearchButton>
+      ></SearchInput>
     </div>
   );
 };
 
-interface SearchButtonProps extends SearchTermProps {
+interface SearchInputProps extends SearchTermProps {
   className: string;
 }
-const SearchButton: React.FC<SearchButtonProps> = ({
+const SearchInput: React.FC<SearchInputProps> = ({
   className,
   performSearch,
   searchTerm,

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -3,6 +3,7 @@ import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { NavMenuGroup } from "../../types/megamenu";
+import CountryDropdown from "../CountryDropdown/CountryDropdown";
 import { MegaIcon } from "../MegaIcon";
 import SubMenuGroup from "../SubMenuGroup/SubMenuGroup";
 
@@ -10,12 +11,14 @@ export interface MobileMenuProps {
   isMobileMenuOpen: boolean;
   menuBarItems: NavMenuGroup[];
   closeMobileMenu: () => void;
+  searchUrl: string;
 }
 
 const MobileMenu: React.FC<MobileMenuProps> = ({
   isMobileMenuOpen,
   menuBarItems,
   closeMobileMenu,
+  searchUrl,
 }) => {
   const [selectedMenuItem, setSelectedMenuItem] =
     React.useState<NavMenuGroup | null>(null);
@@ -64,6 +67,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
             />
           ) : (
             <MenuBarItems
+              url={searchUrl}
               menuBarItems={menuBarItems}
               setSelectedMenuItem={setSelectedMenuItem}
             />
@@ -77,7 +81,8 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
 const MenuBarItems: React.FC<{
   menuBarItems: NavMenuGroup[];
   setSelectedMenuItem: (item: NavMenuGroup) => void;
-}> = ({ menuBarItems, setSelectedMenuItem }) => {
+  searchUrl: string;
+}> = ({ menuBarItems, setSelectedMenuItem, searchUrl }) => {
   const CustomLink = useLinkComponent();
 
   return (
@@ -107,6 +112,7 @@ const MenuBarItems: React.FC<{
           );
         })}
       </div>
+      <CountryDropdown url={searchUrl} />
     </div>
   );
 };

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -21,7 +21,6 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
   setSearchTerm,
   searchTerm,
   performSearch,
-  searchUrl,
 }) => {
   const [selectedMenuItem, setSelectedMenuItem] =
     React.useState<NavMenuGroup | null>(null);

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { NavMenuGroup } from "../../types/megamenu";
 import { MegaIcon } from "../MegaIcon";
-import { SearchTermProps } from "../Search";
+import { SearchInput, SearchTermProps } from "../Search";
 import SubMenuGroup from "../SubMenuGroup/SubMenuGroup";
 
 export interface MobileMenuProps extends SearchTermProps {
@@ -126,45 +126,8 @@ const MenuBarItems: React.FC<MenuBarItemProps> = ({
         setSearchTerm={setSearchTerm}
         searchTerm={searchTerm}
         className="relative pr-6"
-      ></SearchInput>
-    </div>
-  );
-};
-
-interface SearchInputProps extends SearchTermProps {
-  className: string;
-}
-const SearchInput: React.FC<SearchInputProps> = ({
-  className,
-  performSearch,
-  searchTerm,
-  setSearchTerm,
-}) => {
-  return (
-    <div className={className}>
-      <MegaIcon
-        icon="magnifyingGlass"
-        className="pointer-events-none absolute left-4 top-3.5 h-5 w-5 text-ssw-black text-opacity-40"
-        aria-hidden="true"
+        inputClassName="border-radius h-12 grow rounded-l-md border bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
       />
-      <form
-        className="isolate inline-flex w-full rounded-md shadow-sm"
-        onSubmit={(e) => performSearch(e)}
-      >
-        <input
-          type="text"
-          className="border-radius h-12 grow rounded-l-md border bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          placeholder="Search..."
-        />
-        <button
-          type="submit"
-          className="relative -ml-px inline-flex items-center rounded-r-md bg-ssw-red px-3 py-2 text-sm font-semibold text-white hover:bg-ssw-light-red focus:z-10"
-        >
-          Search
-        </button>
-      </form>
     </div>
   );
 };

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -4,9 +4,10 @@ import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { NavMenuGroup } from "../../types/megamenu";
 import { MegaIcon } from "../MegaIcon";
+import { SearchTermProps } from "../Search";
 import SubMenuGroup from "../SubMenuGroup/SubMenuGroup";
 
-export interface MobileMenuProps {
+export interface MobileMenuProps extends SearchTermProps {
   isMobileMenuOpen: boolean;
   menuBarItems: NavMenuGroup[];
   closeMobileMenu: () => void;
@@ -17,6 +18,9 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
   isMobileMenuOpen,
   menuBarItems,
   closeMobileMenu,
+  setSearchTerm,
+  searchTerm,
+  performSearch,
   searchUrl,
 }) => {
   const [selectedMenuItem, setSelectedMenuItem] =
@@ -66,7 +70,9 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
             />
           ) : (
             <MenuBarItems
-              url={searchUrl}
+              setSearchTerm={setSearchTerm}
+              searchTerm={searchTerm}
+              performSearch={performSearch}
               menuBarItems={menuBarItems}
               setSelectedMenuItem={setSelectedMenuItem}
             />
@@ -77,11 +83,18 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
   );
 };
 
-const MenuBarItems: React.FC<{
+interface MenuBarItemProps extends SearchTermProps {
   menuBarItems: NavMenuGroup[];
   setSelectedMenuItem: (item: NavMenuGroup) => void;
   searchUrl: string;
-}> = ({ menuBarItems, setSelectedMenuItem }) => {
+}
+const MenuBarItems: React.FC<MenuBarItemProps> = ({
+  menuBarItems,
+  setSelectedMenuItem,
+  performSearch,
+  setSearchTerm,
+  searchTerm,
+}) => {
   const CustomLink = useLinkComponent();
 
   return (
@@ -111,16 +124,25 @@ const MenuBarItems: React.FC<{
           );
         })}
       </div>
-      <SearchButton className="relative pr-6"></SearchButton>
+      <SearchButton
+        performSearch={performSearch}
+        setSearchTerm={setSearchTerm}
+        searchTerm={searchTerm}
+        className="relative pr-6"
+      ></SearchButton>
     </div>
   );
 };
 
-interface SearchButtonProps {
+interface SearchButtonProps extends SearchTermProps {
   className: string;
 }
-// lint my ball
-const SearchButton: React.FC<SearchButtonProps> = ({ className }) => {
+const SearchButton: React.FC<SearchButtonProps> = ({
+  className,
+  performSearch,
+  searchTerm,
+  setSearchTerm,
+}) => {
   return (
     <div className={className}>
       <MegaIcon
@@ -130,11 +152,13 @@ const SearchButton: React.FC<SearchButtonProps> = ({ className }) => {
       />
       <form
         className="isolate inline-flex w-full rounded-md shadow-sm"
-        // onSubmit={}
+        onSubmit={(e) => performSearch(e)}
       >
         <input
           type="text"
           className="border-radius h-12 grow rounded-l-md border bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
           placeholder="Search..."
         />
         <button

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -3,7 +3,6 @@ import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { NavMenuGroup } from "../../types/megamenu";
-import CountryDropdown from "../CountryDropdown/CountryDropdown";
 import { MegaIcon } from "../MegaIcon";
 import SubMenuGroup from "../SubMenuGroup/SubMenuGroup";
 
@@ -82,11 +81,11 @@ const MenuBarItems: React.FC<{
   menuBarItems: NavMenuGroup[];
   setSelectedMenuItem: (item: NavMenuGroup) => void;
   searchUrl: string;
-}> = ({ menuBarItems, setSelectedMenuItem, searchUrl }) => {
+}> = ({ menuBarItems, setSelectedMenuItem }) => {
   const CustomLink = useLinkComponent();
 
   return (
-    <div className="-my-6 divide-y divide-gray-500/10 pl-6">
+    <div className="-my-6 flex flex-col gap-4 pl-6">
       <div className="space-y-2">
         {menuBarItems.map((item) => {
           return item.url ? (
@@ -112,7 +111,39 @@ const MenuBarItems: React.FC<{
           );
         })}
       </div>
-      <CountryDropdown url={searchUrl} />
+      <SearchButton className="relative pr-6"></SearchButton>
+    </div>
+  );
+};
+
+interface SearchButtonProps {
+  className: string;
+}
+// lint my ball
+const SearchButton: React.FC<SearchButtonProps> = ({ className }) => {
+  return (
+    <div className={className}>
+      <MegaIcon
+        icon="magnifyingGlass"
+        className="pointer-events-none absolute left-4 top-3.5 h-5 w-5 text-ssw-black text-opacity-40"
+        aria-hidden="true"
+      />
+      <form
+        className="isolate inline-flex w-full rounded-md shadow-sm"
+        // onSubmit={}
+      >
+        <input
+          type="text"
+          className="border-radius h-12 grow rounded-l-md border bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
+          placeholder="Search..."
+        />
+        <button
+          type="submit"
+          className="relative -ml-px inline-flex items-center rounded-r-md bg-ssw-red px-3 py-2 text-sm font-semibold text-white hover:bg-ssw-light-red focus:z-10"
+        >
+          Search
+        </button>
+      </form>
     </div>
   );
 };

--- a/lib/components/Search/Search.tsx
+++ b/lib/components/Search/Search.tsx
@@ -114,7 +114,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
           type="text"
           className={
             inputClassName ??
-            "border-radius h-12 grow rounded-l-md border bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
+            "h-12 grow rounded-l-md border bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
           }
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}

--- a/lib/components/Search/Search.tsx
+++ b/lib/components/Search/Search.tsx
@@ -73,37 +73,60 @@ export const Search: React.FC<SearchTermProps> = ({
               leaveTo="opacity-0 scale-95"
             >
               <Dialog.Panel className="mx-auto max-w-2xl divide-y divide-gray-500 divide-opacity-10 overflow-hidden rounded-xl bg-white/80 shadow-2xl backdrop-blur transition-all">
-                <div className="relative">
-                  <MegaIcon
-                    icon="magnifyingGlass"
-                    className="pointer-events-none absolute left-4 top-3.5 h-5 w-5 text-ssw-black text-opacity-40"
-                    aria-hidden="true"
-                  />
-                  <form
-                    className="isolate inline-flex w-full rounded-md shadow-sm"
-                    onSubmit={(e) => handleSearch(e)}
-                  >
-                    <input
-                      ref={searchRef}
-                      type="text"
-                      className="h-12 grow border-0 bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
-                      value={searchTerm}
-                      onChange={(e) => setSearchTerm(e.target.value)}
-                      placeholder="Search..."
-                    />
-                    <button
-                      type="submit"
-                      className="relative -ml-px inline-flex items-center rounded-r-md bg-ssw-red px-3 py-2 text-sm font-semibold text-white hover:bg-ssw-light-red focus:z-10"
-                    >
-                      Search
-                    </button>
-                  </form>
-                </div>
+                <SearchInput
+                  setSearchTerm={setSearchTerm}
+                  searchTerm={searchTerm}
+                  performSearch={handleSearch}
+                />
               </Dialog.Panel>
             </Transition.Child>
           </div>
         </Dialog>
       </Transition.Root>
     </>
+  );
+};
+
+interface SearchInputProps extends SearchTermProps {
+  className: string;
+  inputClassName?: string;
+}
+
+export const SearchInput: React.FC<SearchInputProps> = ({
+  className,
+  performSearch,
+  searchTerm,
+  setSearchTerm,
+  inputClassName,
+}) => {
+  return (
+    <div className={className ?? "relative"}>
+      <MegaIcon
+        icon="magnifyingGlass"
+        className="pointer-events-none absolute left-4 top-3.5 h-5 w-5 text-ssw-black text-opacity-40"
+        aria-hidden="true"
+      />
+      <form
+        className="isolate inline-flex w-full rounded-md shadow-sm"
+        onSubmit={(e) => performSearch(e)}
+      >
+        <input
+          type="text"
+          className={
+            inputClassName ??
+            "border-radius h-12 grow rounded-l-md border bg-transparent pl-11 text-ssw-black focus:ring-0 sm:text-sm"
+          }
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Search..."
+        />
+        <button
+          type="submit"
+          className="relative -ml-px inline-flex items-center rounded-r-md bg-ssw-red px-3 py-2 text-sm font-semibold text-white hover:bg-ssw-light-red focus:z-10"
+        >
+          Search
+        </button>
+      </form>
+    </div>
   );
 };

--- a/lib/components/Search/Search.tsx
+++ b/lib/components/Search/Search.tsx
@@ -3,15 +3,31 @@ import React, { Fragment, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { MegaIcon } from "../MegaIcon";
 
-export interface SearchProps {
-  url?: string;
-  callback?: (searchTerm: string) => void;
+export interface SearchTermProps {
+  searchTerm: string;
+  setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
+  performSearch: (e: React.FormEvent<HTMLFormElement>) => void;
 }
 
-export const Search: React.FC<SearchProps> = ({ url, callback }) => {
-  const searchRef = useRef(null);
+export const Search: React.FC<SearchTermProps> = ({
+  searchTerm,
+  performSearch,
+  setSearchTerm,
+}) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [searchTerm, setSearchTerm] = useState<string>("");
+  const searchRef = useRef(null);
+  useEffect(() => {
+    if (isOpen && searchRef?.current) {
+      const searchInput: HTMLElement = searchRef?.current;
+      searchInput?.focus();
+    }
+  }, [isOpen]);
+
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    performSearch(e);
+    setIsOpen(false);
+    setSearchTerm("");
+  };
 
   useHotkeys(
     "mod+k",
@@ -23,30 +39,6 @@ export const Search: React.FC<SearchProps> = ({ url, callback }) => {
     [isOpen],
     { preventDefault: true },
   );
-
-  useEffect(() => {
-    if (isOpen && searchRef?.current) {
-      const searchInput: HTMLElement = searchRef?.current;
-      searchInput?.focus();
-    }
-  }, [isOpen]);
-
-  const performSearch = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (searchTerm) {
-      if (callback) {
-        callback(searchTerm);
-      } else {
-        const searchUrl = `https://www.google.com.au/search?q=site:${url}%20${encodeURIComponent(
-          searchTerm,
-        )}`;
-        window.open(searchUrl, "_blank");
-      }
-      setIsOpen(false);
-      setSearchTerm("");
-    }
-  };
 
   return (
     <>
@@ -89,7 +81,7 @@ export const Search: React.FC<SearchProps> = ({ url, callback }) => {
                   />
                   <form
                     className="isolate inline-flex w-full rounded-md shadow-sm"
-                    onSubmit={(e) => performSearch(e)}
+                    onSubmit={(e) => handleSearch(e)}
                   >
                     <input
                       ref={searchRef}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,12 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require("tailwindcss/defaultTheme");
 export default {
   content: ["./index.html", "./lib/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
   theme: {
+    screens: {
+      xs: "475px",
+      ...defaultTheme.screens,
+    },
     extend: {
       colors: {
         ssw: {


### PR DESCRIPTION
### Description

This PR updates the mega menu so you can switch between different versions (i.e. French, Chinese) of the site while on a mobile device. I've based the design on a concept designed by @bettybondoc. The search bar for mobile devices has been moved into the side bar so that the language options are immediately visible from the top of the screen.

- Fixed #93 



TLDR: I converted the search box into a dumb component, moved it into the side navigation bar for mobile devices and moved the form state and logic into the main layout component.

### Screenshots



![state preserved between mobile and desktop view](https://github.com/user-attachments/assets/f5c82e46-2080-4b24-9fb8-fd8e8162f17d)

**Figure**: **Search window state preserved between desktop and mobile view**
<br>

<img width="242" alt="image" src="https://github.com/user-attachments/assets/e3efc812-9bb3-4229-b687-c7bfe93c4736">

**Figure**: **New resized window layout**
<br>

<img width="244" alt="image" src="https://github.com/user-attachments/assets/d3837a6c-4321-4832-a46d-e6db3083b4da">

**Figure**: **New sidebar layout**
<br>

<img width="617" alt="image" src="https://github.com/user-attachments/assets/a352407b-d1be-4363-bc3d-3e1bc8a345ca">

**Figure**: **New sidebar open layout**


<br>

![search test navbar](https://github.com/user-attachments/assets/8fc50268-eefd-426b-9dd0-25d5173fe97a)

**Figure**: **Performing a search using the responsive layout**
