### PR TITLE
🔗 Updated link to SSW China

### DIFF
--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -13,7 +13,7 @@ const websites: { country: Countries; url: string }[] = [
   },
   {
     country: "China",
-    url: "https://www.ssw.com.cn",
+    url: "https://www.ssw.cn",
   },
   {
     country: "France",


### PR DESCRIPTION
**Pain**
As per my conversation with @jerryluossw and as per the email 

> RE: SSW China Domains

On https://www.ssw.com.au/, when a user clicks on the China flag in the top right corner, he is sent to ssw.com.cn instead of ssw.cn

**Fix**
I have changed the link on the flag from https://www.ssw.com.cn to https://www.ssw.cn

**Screenshot**
![image](https://github.com/user-attachments/assets/7c74bd79-9e5c-41c1-9207-deb80bdb1506)
Figure: 