### PR TITLE
making menu headings closer to its items

### DIFF
--- a/lib/components/SubMenuGroup/SubMenuGroup.tsx
+++ b/lib/components/SubMenuGroup/SubMenuGroup.tsx
@@ -73,7 +73,7 @@ const Heading: React.FC<{
   children: React.ReactNode;
 }> = ({ className, children }) => {
   return (
-    <h3 className={cx("pb-6 text-lg font-bold text-ssw-black", className)}>
+    <h3 className={cx("pb-4 text-lg font-bold text-ssw-black", className)}>
       {children}
     </h3>
   );


### PR DESCRIPTION
To reduce this green area:

<img width="574" alt="Screenshot 2024-12-09 at 6 34 22 PM" src="https://github.com/user-attachments/assets/5c7ef55a-8a00-4dec-99e5-5b94e5e8d8f3">
