### PR TITLE
⚠️ Fix vite build error

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-const defaultTheme = require("tailwindcss/defaultTheme");
+import defaultTheme from "tailwindcss/defaultTheme";
 export default {
   content: ["./index.html", "./lib/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
   theme: {


### PR DESCRIPTION
### Description 

Our pipeline is now using Node v22.12.0 https://github.com/actions/runner-images/issues/10636

This version of node does not work with the CJS import in our tailwind config file, so I've updated the import to an ESM import