### PR TITLE
Add YouTube and Docs conditional links

### DIFF
--- a/lib/components/SubMenuGroup/SubMenuGroup.tsx
+++ b/lib/components/SubMenuGroup/SubMenuGroup.tsx
@@ -116,49 +116,69 @@ const MenuItem: React.FC<{
 };
 
 const LinkItem: React.FC<{ link: NavMenuColumnGroupItem }> = ({
-  link: { name, url, description, icon, iconImg },
+  link: { name, url, description, icon, iconImg, youtubeLink, documentationLink },
 }) => {
   const close = useContext(ClosePopoverContext);
   const CustomLink = useLinkComponent();
 
   return (
-    <CustomLink
-      href={url || ""}
-      className={cx(
-        "flex items-start gap-x-1 text-ssw-black hover:text-ssw-red focus:outline-none",
-        description ? "p-4" : "p-2",
-      )}
-      onClick={() => {
-        if (close) close();
-      }}
-    >
-      {(icon || iconImg) && (
-        <div className="flex shrink-0 items-center justify-center text-ssw-red">
-          <MegaIcon
-            className="h-6 w-6"
-            icon={icon as AvailableIcons}
-            iconImg={iconImg}
-          />
-        </div>
-      )}
+    <div>
+      <CustomLink
+        href={url || ""}
+        className={cx(
+          "flex items-start gap-x-1 text-ssw-black hover:text-ssw-red focus:outline-none",
+          description ? "p-4" : "p-2",
+        )}
+        onClick={() => {
+          if (close) close();
+        }}
+      >
+        {(icon || iconImg) && (
+          <div className="flex shrink-0 items-center justify-center text-ssw-red">
+            <MegaIcon
+              className="h-6 w-6"
+              icon={icon as AvailableIcons}
+              iconImg={iconImg}
+            />
+          </div>
+        )}
 
-      <div className="min-w-0 flex-1">
-        <span>
-          {name && description ? (
-            <>
-              <p className="font-bold">{name}</p>
-              <p className="mt-1 text-sm font-normal text-ssw-gray">
-                {description}
+        <div className="min-w-0 flex-1">
+          <span>
+            {name && description ? (
+              <>
+                <p className="font-bold">{name}</p>
+                <p className="mt-1 text-sm font-normal text-ssw-gray">
+                  {description}
+                </p>
+              </>
+            ) : (
+              <p className="pl-2 text-sm font-normal text-ssw-black hover:text-ssw-red">
+                {name}
               </p>
-            </>
-          ) : (
-            <p className="pl-2 text-sm font-normal text-ssw-black hover:text-ssw-red">
-              {name}
-            </p>
+            )}
+          </span>
+        </div>
+      </CustomLink>
+      <div className="ml-10 font-light text-ssw-gray flex flex-row gap-x-4 text-sm">
+          {youtubeLink && (
+            <CustomLink
+              href={youtubeLink}
+              className="hover:text-ssw-red"
+            >
+              YouTube
+            </CustomLink>
           )}
-        </span>
+          {documentationLink && (
+            <CustomLink
+              href={documentationLink}
+              className="hover:text-ssw-red"
+            >
+              Docs
+            </CustomLink>
+          )}
       </div>
-    </CustomLink>
+    </div>
   );
 };
 

--- a/lib/components/SubMenuGroup/SubMenuGroup.tsx
+++ b/lib/components/SubMenuGroup/SubMenuGroup.tsx
@@ -116,7 +116,15 @@ const MenuItem: React.FC<{
 };
 
 const LinkItem: React.FC<{ link: NavMenuColumnGroupItem }> = ({
-  link: { name, url, description, icon, iconImg, youtubeLink, documentationLink },
+  link: {
+    name,
+    url,
+    description,
+    icon,
+    iconImg,
+    youtubeLink,
+    documentationLink,
+  },
 }) => {
   const close = useContext(ClosePopoverContext);
   const CustomLink = useLinkComponent();
@@ -160,23 +168,17 @@ const LinkItem: React.FC<{ link: NavMenuColumnGroupItem }> = ({
           </span>
         </div>
       </CustomLink>
-      <div className="ml-10 font-light text-ssw-gray flex flex-row gap-x-4 text-sm">
-          {youtubeLink && (
-            <CustomLink
-              href={youtubeLink}
-              className="hover:text-ssw-red"
-            >
-              YouTube
-            </CustomLink>
-          )}
-          {documentationLink && (
-            <CustomLink
-              href={documentationLink}
-              className="hover:text-ssw-red"
-            >
-              Docs
-            </CustomLink>
-          )}
+      <div className="ml-10 flex flex-row gap-x-4 text-sm font-light text-ssw-gray">
+        {youtubeLink && (
+          <CustomLink href={youtubeLink} className="hover:text-ssw-red">
+            YouTube
+          </CustomLink>
+        )}
+        {documentationLink && (
+          <CustomLink href={documentationLink} className="hover:text-ssw-red">
+            Docs
+          </CustomLink>
+        )}
       </div>
     </div>
   );

--- a/lib/types/megamenu.ts
+++ b/lib/types/megamenu.ts
@@ -31,6 +31,8 @@ export interface NavMenuColumnGroupItem {
   description?: string;
   icon?: AvailableIcons | string;
   iconImg?: string;
+  youtubeLink?: string;
+  documentationLink?: string;
 }
 
 export interface Sidebar {


### PR DESCRIPTION
cc: @landonmaxwell 

PR from PBI - [🟥 SSW Website - Megamenu Products - add Docs & YT link](https://github.com/tinacms/tina.io/issues/2882)

**Changes**
- [ ] (not in this PR but SSW.Website) - added optional fields to sub-menu item schema to account for links to YouTube and Docs 
- [ ] Conditionally render respective links in MegaMenu

![image](https://github.com/user-attachments/assets/8f9f19fc-1432-462c-944b-4a3c3dfbc01e)
**Figure: Added Links**