### PR TITLE
Fixing using "key" pro error appearing in Rules POC while implementing mega.menu package

### DIFF
--- a/lib/components/DesktopMenu/DesktopMenu.tsx
+++ b/lib/components/DesktopMenu/DesktopMenu.tsx
@@ -41,23 +41,17 @@ const DesktopMenu: React.FC<DesktopMenuProps> = ({
             ) {
               return (
                 <Popover key={group.name}>
-                  {({ open, close }) => {
-                    {
-                      /* TODO: Duplicated check needed here to appease Typescript */
-                    }
-                    if (!group.menuColumns || !group.sidebarItems) return <></>;
-                    return (
-                      <MenuContextProvider value={{ close }}>
-                        <MenuItemWithSubmenu
-                          name={group.name}
-                          menuColumns={group.menuColumns}
-                          sidebarItems={group.sidebarItems}
-                          isOpened={open}
-                          viewAll={group.viewAll}
-                        />
-                      </MenuContextProvider>
-                    );
-                  }}
+                  {({ open, close }) => (
+                    <MenuContextProvider value={{ close }}>
+                      <MenuItemWithSubmenu
+                        name={group.name}
+                        menuColumns={group.menuColumns!}
+                        sidebarItems={group.sidebarItems!}
+                        isOpened={open}
+                        viewAll={group.viewAll}
+                      />
+                    </MenuContextProvider>
+                  )}
                 </Popover>
               );
             } else if (group.url) {
@@ -69,7 +63,8 @@ const DesktopMenu: React.FC<DesktopMenuProps> = ({
                 />
               );
             } else {
-              return <></>;
+              // avoids returning unkeyed fragments.
+              return null;
             }
           })}
         </Popover.Group>


### PR DESCRIPTION
This a PR that should fix a "unique key prop" error raised while we tried to implement mega.menu package on our POC Rules website.

The error.
`Each child in a list should have a unique "key" prop. Check the render method of `gt`. It was passed a child from DesktopMenu.`

The file where we are using the mega.menu package in SSW POC Rules: https://github.com/SSWConsulting/SSW.Rules.Tina.Nextjs.POC/blob/1890-Header_Footer_Migration/components/server/MegaMenuWrapper.tsx