### PR TITLE
Show/Hide Flag drop down in mobile view

### DIFF
--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -51,7 +51,7 @@ const CountryDropdown = ({ url, className }: CountryDropdownProps) => {
     <Popover className={cx(className)}>
       <Popover.Button
         className={cx(
-          "flex items-center justify-center gap-x-1 rounded-md px-4 py-1 xs:px-5 text-sm font-semibold text-ssw-black outline-none",
+          "flex items-center justify-center gap-x-1 rounded-md px-4 py-1 text-sm font-semibold text-ssw-black outline-none xs:px-5",
           "hover:scale-105",
         )}
         onClick={() => setIsOpened(!isOpened)}

--- a/lib/components/CountryDropdown/CountryDropdown.tsx
+++ b/lib/components/CountryDropdown/CountryDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Popover, Transition } from "@headlessui/react";
+import type { ClassValue } from "clsx";
 import { Fragment, useEffect, useState } from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { Countries } from "../../types/country";
@@ -23,9 +24,10 @@ const websites: { country: Countries; url: string }[] = [
 
 type CountryDropdownProps = {
   url?: string;
+  className?: ClassValue;
 };
 
-const CountryDropdown = ({ url }: CountryDropdownProps) => {
+const CountryDropdown = ({ url, className }: CountryDropdownProps) => {
   const [isOpened, setIsOpened] = useState(false);
   const [currentCountry, setCurrentCountry] = useState<Countries>("Australia");
 
@@ -46,10 +48,10 @@ const CountryDropdown = ({ url }: CountryDropdownProps) => {
   }, [url]);
 
   return (
-    <Popover>
+    <Popover className={cx(className)}>
       <Popover.Button
         className={cx(
-          "flex items-center justify-center gap-x-1 rounded-md px-1 py-1 text-sm font-semibold text-ssw-black outline-none xs:px-4",
+          "flex items-center justify-center gap-x-1 rounded-md px-4 py-1 xs:px-5 text-sm font-semibold text-ssw-black outline-none",
           "hover:scale-105",
         )}
         onClick={() => setIsOpened(!isOpened)}

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -27,6 +27,7 @@ export type MegaMenuWrapperProps = {
   rightSideActionsOverride?: () => JSX.Element;
   callback?: (searchTerm: string) => void;
   linkComponent?: LinkComponentType;
+  isFlagVisible?: boolean;
 } & React.PropsWithChildren &
   (Tagline | Title);
 
@@ -50,6 +51,7 @@ const MegaMenuContents: React.FC<MegaMenuWrapperProps> = ({
   menuBarItems,
   rightSideActionsOverride,
   callback,
+  isFlagVisible = true,
 }) => {
   const [searchTerm, setSearchTerm] = useState<string>("");
   const performSearch = (e: React.FormEvent<HTMLFormElement>) => {
@@ -115,8 +117,8 @@ const MegaMenuContents: React.FC<MegaMenuWrapperProps> = ({
             ) : (
               <PhoneButton className="max-sm:hidden" />
             )}
-            <CountryDropdown className="max-sm:hidden" />
-            <Divider className="max-sm:hidden" />
+            {isFlagVisible && <CountryDropdown />}
+            {isFlagVisible && <Divider />} 
             <button
               type="button"
               className="inline-flex items-center justify-center rounded-md px-1 text-gray-700 xs:px-4"

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -118,7 +118,7 @@ const MegaMenuContents: React.FC<MegaMenuWrapperProps> = ({
               <PhoneButton className="max-sm:hidden" />
             )}
             {isFlagVisible && <CountryDropdown />}
-            {isFlagVisible && <Divider />} 
+            {isFlagVisible && <Divider />}
             <button
               type="button"
               className="inline-flex items-center justify-center rounded-md px-1 text-gray-700 xs:px-4"

--- a/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
+++ b/lib/components/MegaMenuLayout/MegaMenuLayout.tsx
@@ -16,6 +16,7 @@ import DesktopMenu from "../DesktopMenu/DesktopMenu";
 import { Logo } from "../Logo";
 import MobileMenu from "../MobileMenu/MobileMenu";
 import { PhoneButton } from "../PhoneButton";
+import { Divider } from "../ui/Divider";
 
 export type MegaMenuWrapperProps = {
   className?: ClassValue;
@@ -114,8 +115,8 @@ const MegaMenuContents: React.FC<MegaMenuWrapperProps> = ({
             ) : (
               <PhoneButton className="max-sm:hidden" />
             )}
-            <CountryDropdown />
-            <Divider />
+            <CountryDropdown className="max-sm:hidden" />
+            <Divider className="max-sm:hidden" />
             <button
               type="button"
               className="inline-flex items-center justify-center rounded-md px-1 text-gray-700 xs:px-4"
@@ -153,10 +154,6 @@ const MegaMenuContents: React.FC<MegaMenuWrapperProps> = ({
       )}
     </>
   );
-};
-
-const Divider: React.FC = () => {
-  return <div className="h-4 w-px bg-gray-700/30 sm:block"></div>;
 };
 
 const MegaMenuLayout: React.FC<MegaMenuWrapperProps> = ({

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -35,7 +35,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
         <div className="flex h-16 items-center justify-end p-4">
           <button
             type="button"
-            className="p-2 xs:p-4 text-gray-700"
+            className="p-2 text-gray-700 xs:p-4"
             onClick={onCloseMobileMenu}
           >
             <span className="sr-only">Close menu</span>
@@ -55,8 +55,8 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
         </div>
         <div className="flow-root">
           {selectedMenuItem &&
-            selectedMenuItem.menuColumns &&
-            selectedMenuItem.sidebarItems ? (
+          selectedMenuItem.menuColumns &&
+          selectedMenuItem.sidebarItems ? (
             <MenuContextProvider value={{ close: onCloseMobileMenu }}>
               <SubMenuGroup
                 menuColumns={selectedMenuItem.menuColumns}

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -4,9 +4,11 @@ import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { MenuContextProvider } from "../../hooks/useMenuState";
 import { NavMenuGroup } from "../../types/megamenu";
+import { CountryDropdown } from "../CountryDropdown";
 import { MegaIcon } from "../MegaIcon";
 import { SearchInput, SearchTermProps } from "../Search";
 import SubMenuGroup from "../SubMenuGroup/SubMenuGroup";
+import { Divider } from "../ui/Divider";
 
 export interface MobileMenuProps extends SearchTermProps {
   isMobileMenuOpen: boolean;
@@ -30,12 +32,14 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
   };
   return (
     <Dialog as="div" open={isMobileMenuOpen} onClose={onCloseMobileMenu}>
-      <div className="fixed  inset-0 z-10" />
+      <div className="fixed inset-0 z-10" />
       <Dialog.Panel className="fixed inset-y-0 right-0 z-10 w-full overflow-y-auto bg-white sm:max-w-sm sm:ring-1 sm:ring-ssw-black/10 xl:hidden">
-        <div className="flex h-16 flex-row-reverse">
+        <div className="flex h-16 items-center justify-end p-4">
+          <CountryDropdown className="sm:hidden" />
+          <Divider className="sm:hidden" />
           <button
             type="button"
-            className="p-4 text-gray-700"
+            className="p-2 xs:p-4 text-gray-700"
             onClick={onCloseMobileMenu}
           >
             <span className="sr-only">Close menu</span>
@@ -55,8 +59,8 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
         </div>
         <div className="flow-root">
           {selectedMenuItem &&
-          selectedMenuItem.menuColumns &&
-          selectedMenuItem.sidebarItems ? (
+            selectedMenuItem.menuColumns &&
+            selectedMenuItem.sidebarItems ? (
             <MenuContextProvider value={{ close: onCloseMobileMenu }}>
               <SubMenuGroup
                 menuColumns={selectedMenuItem.menuColumns}

--- a/lib/components/MobileMenu/MobileMenu.tsx
+++ b/lib/components/MobileMenu/MobileMenu.tsx
@@ -4,11 +4,9 @@ import React from "react";
 import { useLinkComponent } from "../../hooks/useLinkComponent";
 import { MenuContextProvider } from "../../hooks/useMenuState";
 import { NavMenuGroup } from "../../types/megamenu";
-import { CountryDropdown } from "../CountryDropdown";
 import { MegaIcon } from "../MegaIcon";
 import { SearchInput, SearchTermProps } from "../Search";
 import SubMenuGroup from "../SubMenuGroup/SubMenuGroup";
-import { Divider } from "../ui/Divider";
 
 export interface MobileMenuProps extends SearchTermProps {
   isMobileMenuOpen: boolean;
@@ -35,8 +33,6 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
       <div className="fixed inset-0 z-10" />
       <Dialog.Panel className="fixed inset-y-0 right-0 z-10 w-full overflow-y-auto bg-white sm:max-w-sm sm:ring-1 sm:ring-ssw-black/10 xl:hidden">
         <div className="flex h-16 items-center justify-end p-4">
-          <CountryDropdown className="sm:hidden" />
-          <Divider className="sm:hidden" />
           <button
             type="button"
             className="p-2 xs:p-4 text-gray-700"

--- a/lib/components/ui/Divider.tsx
+++ b/lib/components/ui/Divider.tsx
@@ -2,5 +2,5 @@ import type { ClassValue } from "clsx";
 import { cx } from "../../util/cx";
 
 export const Divider = ({ className }: { className?: ClassValue }) => (
-    <div className={cx("h-4 w-px bg-gray-700/30", className)}></div>
+  <div className={cx("h-4 w-px bg-gray-700/30", className)}></div>
 );

--- a/lib/components/ui/Divider.tsx
+++ b/lib/components/ui/Divider.tsx
@@ -1,0 +1,6 @@
+import type { ClassValue } from "clsx";
+import { cx } from "../../util/cx";
+
+export const Divider = ({ className }: { className?: ClassValue }) => (
+    <div className={cx("h-4 w-px bg-gray-700/30", className)}></div>
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssw.megamenu",
-  "version": "4.13.2",
+  "version": "4.13.3",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ function App() {
         <MegaMenuLayout
           title="Rules"
           subtitle="Secret ingredients to quality software"
-          isFlagVisible={false}
         />
       </div>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ function App() {
         <MegaMenuLayout
           title="Rules"
           subtitle="Secret ingredients to quality software"
+          isFlagVisible={false}
         />
       </div>
     </>


### PR DESCRIPTION
Hiding flag drop down in mobile view and moving it to the mobile menu (hamburger menu)

<img width="425" height="361" alt="image" src="https://github.com/user-attachments/assets/b5f24330-d5a7-49d0-99e3-432a4021a44e" />

Figure: Hidden in mobile view

<img width="425" height="444" alt="image" src="https://github.com/user-attachments/assets/5449051f-b91f-4fb7-9c3f-32d32b632f6b" />

Figure: Moved into hamburger menu in mobile

<img width="982" height="519" alt="image" src="https://github.com/user-attachments/assets/cc716d20-e45e-4bac-9a4a-1edb3d1ce15f" />

Figure: Reversed display for desktop size